### PR TITLE
apply chaining using an accessor generator role

### DIFF
--- a/lib/MooX/ChainedAttributes/Role/GenerateAccessor.pm
+++ b/lib/MooX/ChainedAttributes/Role/GenerateAccessor.pm
@@ -1,0 +1,26 @@
+package MooX::ChainedAttributes::Role::GenerateAccessor;
+use Moo::Role;
+
+around is_simple_set => sub {
+    my $orig = shift;
+    my $self = shift;
+    my ($attr, $spec) = @_;
+    return 0
+        if $spec->{chained};
+    $self->$orig(@_);
+};
+
+around _generate_set => sub {
+    my $orig = shift;
+    my $self = shift;
+    my ($attr, $spec) = @_;
+    my $chained = $spec->{chained};
+    local $spec->{chained};
+    my $set = $self->$orig(@_);
+    return $set
+        if !$chained;
+
+    "(scalar ($set, \$_[0]))";
+};
+
+1;

--- a/t/chained.t
+++ b/t/chained.t
@@ -60,4 +60,20 @@ is( $f->_set_foo3(19), $f, 'rwp chained' );
 is( $f->set_foo4(98), $f, 'rw chained writer' );
 is( $f->set_foo5(77), $f, 'rwp chained writer' );
 
+{
+    package Foo2;
+
+    use Moo;
+    use MooX::ChainedAttributes;
+
+    has foo2 => (
+        is => 'rw',
+    );
+
+    chain 'foo2';
+}
+
+my $f2 = Foo2->new;
+is( $f2->foo2(56), $f2, 'make existing attribute chained' );
+
 done_testing;


### PR DESCRIPTION
Rather than wrapping accessors in an additional sub, which will cause a
speed hit, modify the code generated for the accessors.
